### PR TITLE
Fixed regex for irc user (nickname)

### DIFF
--- a/schemas/irc-request.yml
+++ b/schemas/irc-request.yml
@@ -12,6 +12,7 @@ properties:
       either `user` or `channel`, you cannot supply both.
   user:
     type:           string
+    pattern:        "^[A-Za-z\\[\\]\\\\~_\\^{|}][A-Za-z0-9\\-\\[\\]\\\\~_\\^{|}]{0,254}$",
     maxLength:      255
     minLength:      1
     description: |


### PR DESCRIPTION
Based on the following specifications, I believe this is right. Also it seems to work with http://www.jsonschemavalidator.net/. The first link below amused me (the second paragraph invalidating the first).

* https://tools.ietf.org/html/rfc2812#section-1.2.1
* https://tools.ietf.org/html/rfc2812#section-2.3.1 (see "nickname")
* https://tools.ietf.org/html/rfc5234 (to understand syntax of previous bullet point)
* http://json-schema.org/latest/json-schema-validation.html#anchor33 (shows that `pattern` uses js regex grammar)
* http://www.ecma-international.org/ecma-262/5.1/#sec-A.7 (js regex grammar)