### PR TITLE
Check for irc channel correctness

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Example routes:
 ]
 ```
 
-Further specification of this is contained in the docs.
+Further specification of this is contained in the docs. **Note: The channel should have the # preceeding it.**
 
 Testing
 -------

--- a/src/notifier.js
+++ b/src/notifier.js
@@ -106,6 +106,10 @@ class Notifier {
   }
 
   async irc({channel, user, message}) {
+    if (channel && !/^[#&][^ ,\u{0007}]{1,199}$/u.test(channel)) {
+      debug('imatchrc channel ' + channel + ' invalid format. Not attempting to send.');
+      return;
+    }
     if (this.isDuplicate(channel, user, message)) {
       debug('Duplicate irc message send detected. Not attempting resend.');
       return;


### PR DESCRIPTION
This is for when people specify things in `task.routes`. The api endpoint has a proper schema already.

Would it be good to also prepend a `#` if they fail to specify one or just silently fail like this?