### PR TITLE
Allow setting custom messages from task definitions

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -72,3 +72,5 @@ test:
     realName:         Taskcluster Test Robot
     queueName:        irc-test-notifications
     port:             6697
+  pulse:
+    fake: true

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -41,6 +41,26 @@ But what you've really been waiting for is to know how to use this, so here's a 
 }
 ```
 
+### Setting Custom Messages
+
+In both irc and email you can set custom messages by adding fields to your task definition. The fields will be rendered with [jsone](https://taskcluster.github.io/json-e/)
+given a context of the [task definition](https://docs.taskcluster.net/reference/platform/taskcluster-queue/references/api#get-task-definition)
+and [task status](https://docs.taskcluster.net/reference/platform/taskcluster-queue/references/events#message-payload-4). The task definition is in the context under the key
+`task` and the status is in the context under the key `status`. The fields you add to your task definition are all in the `task.extra` section under a key `notify`. They are as follows:
+
+__task.extra.notify.ircUserMessage:__ This should evaluate to a string and is the message sent to a user in irc if a `notify.irc-user` event occurs
+
+__task.extra.notify.ircChannelMessage:__ This should evaluate to a string and is the message posted to a channel in irc if a `notify.irc-channel` event occurs
+
+__task.extra.notify.email.content:__ This should evaluate to a markdown string and is the body of an email
+
+__task.extra.notify.email.subject:__ This should evaluate to a normal string and is the subject of an email
+
+__task.extra.notify.email.link:__ This should evaluate to an object with `text` (which will be the text on the button) and `href` keys or null if you don not want a link in your email
+
+__task.extra.notify.email.template:__ This should evaluate to string with a value of either 'simple' or 'fullscreen' at this time
+
+
 ### Scopes
 
 If you're using this from the api instead of via a task definition, you'll need some simple ``notify.<type>.*`` scopes of some sort. The specific ones you need are documented on the [api docs](https://docs.taskcluster.net/reference/core/notify/api-docs).
@@ -73,6 +93,9 @@ tasks:
       - "notify.irc-channel.#taskcluster-notifications.on-failed"
       - "notify.irc-channel.#taskcluster-notifications.on-exception"
     extra:
+      notify:
+        email:
+          content: 'Things worked in ${status.taskId}',
       github:
         env: true
         events:

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "eslint-config-taskcluster": "^2.0.0",
     "eslint-plugin-taskcluster": "^1.0.2",
     "irc": "^0.5.0",
-    "jsone": "^0.0.0",
+    "json-e": "^2.3.4",
     "lodash": "^4.11.1",
     "marked": "^0.3.5",
     "mocha": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -34,9 +34,10 @@
     "node-sass": "^3.8.0",
     "promise": "^7.1.1",
     "pug": "^2.0.0-beta5",
-    "pulse-publisher": "^1.1.4",
+    "pulse-publisher": "^3.0.2",
     "slugid": "^1.1.0",
     "source-map-support": "^0.4.0",
+    "taskcluster-client": "^3.1.0",
     "taskcluster-lib-api": "3.2.2",
     "taskcluster-lib-app": "^1.0.0",
     "taskcluster-lib-docs": "^3.0.0",
@@ -50,5 +51,8 @@
   "engines": {
     "node": "7.10.1",
     "yarn": "0.27.5"
+  },
+  "devDependencies": {
+    "sinon": "^4.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "eslint-config-taskcluster": "^2.0.0",
     "eslint-plugin-taskcluster": "^1.0.2",
     "irc": "^0.5.0",
+    "jsone": "^0.0.0",
     "lodash": "^4.11.1",
     "marked": "^0.3.5",
     "mocha": "^2.2.1",

--- a/src/handler.js
+++ b/src/handler.js
@@ -2,6 +2,7 @@ let debug = require('debug')('notify');
 let _ = require('lodash');
 let assert = require('assert');
 let taskcluster = require('taskcluster-client');
+let jsone = require('json-e');
 
 /** Handler listening for tasks that carries notifications */
 class Handler {
@@ -73,7 +74,7 @@ class Handler {
         case 'irc-channel':
           this.monitor.count('notification-requested.irc-channel');
           if (_.has(task, 'extra.notify.irc-channel.message')) {
-            message = jsone(_.get(task, 'extra.notify.irc-user.message'), status);
+            message = jsone(_.get(task, 'extra.notify.irc-channel.message'), status);
           }
           return this.notifier.irc({
             channel: route[2],

--- a/src/handler.js
+++ b/src/handler.js
@@ -58,27 +58,27 @@ class Handler {
         return;
       }
 
-      let ircmessage = `Task "${task.metadata.name}" complete with status '${status.state}'. Inspect: ${href}`;
+      let ircMessage = `Task "${task.metadata.name}" complete with status '${status.state}'. Inspect: ${href}`;
 
       switch (route[1]) {
         case 'irc-user':
           this.monitor.count('notification-requested.irc-user');
-          if (_.has(task, 'extra.notify.irc-user.message')) {
-            message = jsone(_.get(task, 'extra.notify.irc-user.message'), status);
+          if (_.has(task, 'extra.notify.ircUserMessage')) {
+            ircMessage = jsone(task.extra.notify.ircUserMessage, {task, status});
           }
           return this.notifier.irc({
             user: route[2],
-            message: ircmessage,
+            message: ircMessage,
           });
 
         case 'irc-channel':
           this.monitor.count('notification-requested.irc-channel');
-          if (_.has(task, 'extra.notify.irc-channel.message')) {
-            message = jsone(_.get(task, 'extra.notify.irc-channel.message'), status);
+          if (_.has(task, 'extra.notify.ircChannelMessage')) {
+            ircMessage = jsone(task.extra.notify.ircChannelMessage, {task, status});
           }
           return this.notifier.irc({
             channel: route[2],
-            message: ircmessage,
+            message: ircMessage,
           });
 
         case 'pulse':
@@ -104,10 +104,10 @@ Task [\`${taskId}\`](${href}) in task-group [\`${task.taskGroupId}\`](${groupHre
           let template = 'simple';
           if (_.has(task, 'extra.notify.email')) {
             let extra = task.extra.notify.email;
-            content = email.content ? jsone(email.content, status) : content;
-            subject = email.subject ? jsone(email.subject, status) : subject;
-            link = email.link ? jsone(email.link, status) : link;
-            template = email.template ? jsone(email.template, status) : template;
+            content = email.content ? jsone(email.content, {task, status}) : content;
+            subject = email.subject ? jsone(email.subject, {task, status}) : subject;
+            link = email.link ? jsone(email.link, {task, status}) : link;
+            template = email.template ? jsone(email.template, {task, status}) : template;
           }
           return this.notifier.email({
             address:  _.join(_.slice(route, 2, route.length - 1), '.'),

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -7,12 +7,11 @@ suite('API', () => {
   });
 
   test('pulse', async (done) => {
-    await helper.events.listenFor('notification', helper.notifyEvents.notify({}));
-    helper.events.waitFor('notification').then(message => {
+    helper.publisher.on('fakePublish', message => {
       assert.deepEqual(message.payload.message, {test: 123});
-      assert.deepEqual(message.routes, ['notify-test']);
+      assert.deepEqual(message.CCs, ['route.notify-test']);
       done();
-    }).catch(done);
+    });
     await helper.notify.pulse({routingKey: 'notify-test', message: {test: 123}});
   });
 

--- a/test/handler_test.js
+++ b/test/handler_test.js
@@ -3,12 +3,18 @@ suite('Handler', () => {
   let mocha = require('mocha');
   let debug = require('debug')('test');
   let testing = require('taskcluster-lib-testing');
-  let slugid = require('slugid');
+  let sinon = require('sinon');
   let helper = require('./helper');
   let load = require('../lib/main');
 
+  let publisher;
+  let listener;
+  let queue = {};
+
   mocha.before(async () => {
-    await load('handler', {profile: 'test', process: 'test'});
+    publisher = await load('publisher', {profile: 'test', process: 'test'});
+    listener = await load('listener', {profile: 'test', process: 'test'});
+    await load('handler', {profile: 'test', process: 'test', listener, queue, publisher});
   });
 
   // Create datetime for created and deadline as 25 minutes later
@@ -40,52 +46,80 @@ suite('Handler', () => {
     };
   };
 
-  test('pulse', async (done) => {
-    let taskId = slugid.v4();
-    await helper.events.listenFor('notification', helper.notifyEvents.notify({}));
-    helper.events.waitFor('notification').then(message => {
-      assert.deepEqual(message.routes, ['notify-test']);
-      done();
-    }).catch(done);
+  let baseStatus = {
+    taskId: 'DKPZPsvvQEiw67Pb3rkdNg',
+    provisionerId: 'aws-provisioner-v1',
+    workerType: 'gecko-t-win7-32-gpu',
+    schedulerId: 'gecko-level-3',
+    taskGroupId: 'NA3wajh1SQ-yVPlNUO8OYw',
+    deadline: '2017-11-23T20:52:34.298Z',
+    expires: '2018-11-22T20:52:34.298Z',
+    retriesLeft: 5,
+    state: 'completed',
+    runs: [
+      {
+        runId: 0,
+        state: 'completed',
+        reasonCreated: 'scheduled',
+        reasonResolved: 'completed',
+        workerGroup: 'us-east-1',
+        workerId: 'i-07289601f12347a8b',
+        takenUntil: '2017-11-22T22:40:54.604Z',
+        scheduled: '2017-11-22T22:20:54.016Z',
+        started: '2017-11-22T22:20:54.682Z',
+        resolved: '2017-11-22T22:26:48.774Z',
+      },
+    ],
+  };
 
-    let task = makeTask(['test-notify.pulse.notify-test.on-any']);
-    await helper.queue.createTask(taskId, task);
-    await helper.queue.claimTask(taskId, 0, {
-      workerGroup:  'dummy-test-workergroup',
-      workerId:     'dummy-test-worker-id',
+  test('pulse', async (done) => {
+    publisher.on('fakePublish', ({CCs}) => {
+      assert.deepEqual(CCs, ['route.notify-test']);
+      done();
     });
-    await testing.sleep(100);
-    await helper.queue.reportCompleted(taskId, 0);
+
+    let route = 'test-notify.pulse.notify-test.on-any';
+    queue.task = sinon.stub().returns(makeTask([route]));
+    await listener.fakeMessage({
+      payload: {
+        status: baseStatus,
+      },
+      exchange: 'exchange/taskcluster-queue/v1/task-completed',
+      routingKey: 'doesnt-matter',
+      routes: [route],
+    });
   });
 
   test('email', async (done) => {
-    let taskId = slugid.v4();
     helper.checkSqsMessage(helper.emailSqsQueueUrl, done, body => {
       let j = JSON.parse(body.Message);
       assert.deepEqual(j.delivery.recipients, ['success@simulator.amazonses.com']);
     });
-    let task = makeTask(['test-notify.email.success@simulator.amazonses.com.on-any']);
-    await helper.queue.createTask(taskId, task);
-    await helper.queue.claimTask(taskId, 0, {
-      workerGroup:  'dummy-test-workergroup',
-      workerId:     'dummy-test-worker-id',
+    let route = 'test-notify.email.success@simulator.amazonses.com.on-any';
+    queue.task = sinon.stub().returns(makeTask([route]));
+    await listener.fakeMessage({
+      payload: {
+        status: baseStatus,
+      },
+      exchange: 'exchange/taskcluster-queue/v1/task-completed',
+      routingKey: 'doesnt-matter',
+      routes: [route],
     });
-    await testing.sleep(100);
-    await helper.queue.reportCompleted(taskId, 0);
   });
 
   test('irc', async (done) => {
-    let taskId = slugid.v4();
     helper.checkSqsMessage(helper.sqsQueueUrl, done, body => {
       assert.equal(body.channel, '#taskcluster-test');
     });
-    let task = makeTask(['test-notify.irc-channel.#taskcluster-test.on-any']);
-    await helper.queue.createTask(taskId, task);
-    await helper.queue.claimTask(taskId, 0, {
-      workerGroup:  'dummy-test-workergroup',
-      workerId:     'dummy-test-worker-id',
+    let route = 'test-notify.irc-channel.#taskcluster-test.on-any';
+    queue.task = sinon.stub().returns(makeTask([route]));
+    listener.fakeMessage({
+      payload: {
+        status: baseStatus,
+      },
+      exchange: 'exchange/taskcluster-queue/v1/task-completed',
+      routingKey: 'doesnt-matter',
+      routes: [route],
     });
-    await testing.sleep(100);
-    await helper.queue.reportCompleted(taskId, 0);
   });
 });

--- a/test/handler_test.js
+++ b/test/handler_test.js
@@ -110,10 +110,11 @@ suite('Handler', () => {
   test('irc', async (done) => {
     helper.checkSqsMessage(helper.sqsQueueUrl, done, body => {
       assert.equal(body.channel, '#taskcluster-test');
+      assert.equal(body.message, 'it worked with taskid DKPZPsvvQEiw67Pb3rkdNg');
     });
     let route = 'test-notify.irc-channel.#taskcluster-test.on-any';
     let task = makeTask([route]);
-    task.extra = {notify: {'irc-channel': {message: 'it worked with taskid'}}};
+    task.extra = {notify: {ircChannelMessage: 'it worked with taskid ${status.taskId}'}};
     queue.task = sinon.stub().returns(task);
     listener.fakeMessage({
       payload: {

--- a/test/handler_test.js
+++ b/test/handler_test.js
@@ -112,7 +112,9 @@ suite('Handler', () => {
       assert.equal(body.channel, '#taskcluster-test');
     });
     let route = 'test-notify.irc-channel.#taskcluster-test.on-any';
-    queue.task = sinon.stub().returns(makeTask([route]));
+    let task = makeTask([route]);
+    task.extra = {notify: {'irc-channel': {message: 'it worked with taskid'}}};
+    queue.task = sinon.stub().returns(task);
     listener.fakeMessage({
       payload: {
         status: baseStatus,

--- a/test/helper.js
+++ b/test/helper.js
@@ -54,7 +54,8 @@ mocha.before(async () => {
   // Create mock authentication server
   testing.fakeauth.start(testclients);
 
-  webServer = await load('server', {profile: 'test', process: 'test'});
+  helper.publisher = await load('publisher', {profile: 'test', process: 'test'});
+  webServer = await load('server', {profile: 'test', process: 'test', publisher: helper.publisher});
 
   // Create client for working with API
   helper.baseUrl = 'http://localhost:' + webServer.address().port + '/v1';
@@ -75,7 +76,6 @@ mocha.before(async () => {
   });
   helper.NotifyEvents = taskcluster.createClient(exchangeReference);
   helper.notifyEvents = new helper.NotifyEvents();
-  helper.events = new testing.PulseTestReceiver(cfg.pulse, mocha);
 
   // Create client for listening for irc requests
   helper.sqs = new aws.SQS(cfg.aws);

--- a/user-config-example.yml
+++ b/user-config-example.yml
@@ -1,11 +1,4 @@
 defaults:
-  taskcluster:
-    credentials:
-      clientId:         '...'
-      accessKey:        '...'
   aws:
     accessKeyId:        '...'
     secretAccessKey:    '...'
-  pulse:
-    username:           '...'
-    password:           '...'

--- a/yarn.lock
+++ b/yarn.lock
@@ -58,6 +58,15 @@ ajv@^4.0.4, ajv@^4.7.0, ajv@^4.8.2, ajv@^4.9.1:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
 
+ajv@^5.3.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.4.0.tgz#32d1cf08dbc80c432f426f12e10b2511f6b46474"
+  dependencies:
+    co "^4.6.0"
+    fast-deep-equal "^1.0.0"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.3.0"
+
 align-text@^0.1.1, align-text@^0.1.3:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/align-text/-/align-text-0.1.4.tgz#0cd90a561093f35d0a99256c22b7069433fad117"
@@ -206,6 +215,21 @@ async@~0.2.10:
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+
+aws-sdk@^2.148.0:
+  version "2.155.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.155.0.tgz#2ae5381f97e8f42e650e1d25999e9090a936d0c6"
+  dependencies:
+    buffer "4.9.1"
+    crypto-browserify "1.0.9"
+    events "^1.1.1"
+    jmespath "0.15.0"
+    querystring "0.2.0"
+    sax "1.2.1"
+    url "0.10.3"
+    uuid "3.1.0"
+    xml2js "0.4.17"
+    xmlbuilder "4.2.1"
 
 aws-sdk@^2.2.28, aws-sdk@^2.2.38, aws-sdk@^2.4.11, aws-sdk@^2.4.9, aws-sdk@^2.5.3:
   version "2.24.0"
@@ -643,12 +667,19 @@ babel-runtime@^5.8.25:
   dependencies:
     core-js "^1.0.0"
 
-babel-runtime@^6.0.0, babel-runtime@^6.0.14, babel-runtime@^6.1.18, babel-runtime@^6.11.6, babel-runtime@^6.18.0, babel-runtime@^6.20.0, babel-runtime@^6.22.0, babel-runtime@^6.6.1:
+babel-runtime@^6.0.0, babel-runtime@^6.0.14, babel-runtime@^6.1.18, babel-runtime@^6.11.6, babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.6.1:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.23.0.tgz#0a9489f144de70efb3ce4300accdb329e2fc543b"
   dependencies:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
+
+babel-runtime@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
+  dependencies:
+    core-js "^2.4.0"
+    regenerator-runtime "^0.11.0"
 
 babel-template@^6.22.0, babel-template@^6.23.0:
   version "6.23.0"
@@ -769,6 +800,18 @@ boom@2.x.x:
   resolved "https://registry.yarnpkg.com/boom/-/boom-2.10.1.tgz#39c8918ceff5799f83f9492a848f625add0c766f"
   dependencies:
     hoek "2.x.x"
+
+boom@4.x.x:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/boom/-/boom-4.3.1.tgz#4f8a3005cb4a7e3889f749030fd25b96e01d2e31"
+  dependencies:
+    hoek "4.x.x"
+
+boom@5.x.x:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/boom/-/boom-5.2.0.tgz#5dd9da6ee3a5f302077436290cb717d3f4a54e02"
+  dependencies:
+    hoek "4.x.x"
 
 brace-expansion@^1.0.0:
   version "1.1.6"
@@ -993,7 +1036,7 @@ component-emitter@1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.1.2.tgz#296594f2753daa63996d2af08d15a95116c9aec3"
 
-component-emitter@~1.2.0:
+component-emitter@^1.2.0, component-emitter@~1.2.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
 
@@ -1054,6 +1097,10 @@ cookiejar@2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.0.6.tgz#0abf356ad00d1c5a219d88d44518046dd026acfe"
 
+cookiejar@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.1.tgz#41ad57b1b555951ec171412a81942b1e8200d34a"
+
 core-js@^1.0.0:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
@@ -1101,6 +1148,12 @@ cryptiles@2.x.x, cryptiles@^2.0.4:
   resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-2.0.5.tgz#3bdfecdc608147c1c67202fa291e7dca59eaa3b8"
   dependencies:
     boom "2.x.x"
+
+cryptiles@3.x.x:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-3.1.2.tgz#a89fbb220f5ce25ec56e8c4aa8a4fd7b5b0d29fe"
+  dependencies:
+    boom "5.x.x"
 
 crypto-browserify@1.0.9:
   version "1.0.9"
@@ -1158,7 +1211,7 @@ datauri@~0.2.0:
     mimer "*"
     templayed "*"
 
-debug@2, debug@^2.0.0, debug@^2.1.1, debug@^2.1.3, debug@^2.2.0:
+debug@2, debug@^2.1.1, debug@^2.1.3, debug@^2.2.0:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.1.tgz#79855090ba2c4e3115cc7d8769491d58f0491351"
   dependencies:
@@ -1169,6 +1222,12 @@ debug@2.2.0, debug@~2.2.0:
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.2.0.tgz#f87057e995b1a1f6ae6a4960664137bc56f039da"
   dependencies:
     ms "0.7.1"
+
+debug@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  dependencies:
+    ms "2.0.0"
 
 debug@~1.0.1:
   version "1.0.4"
@@ -1257,6 +1316,10 @@ detect-indent@^4.0.0:
 diff@1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-1.4.0.tgz#7f28d2eb9ee7b15a97efd89ce63dcfdaa3ccbabf"
+
+diff@^3.1.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.4.0.tgz#b1d85507daf3964828de54b37d0d73ba67dda56c"
 
 doctrine@^1.2.2:
   version "1.5.0"
@@ -1574,6 +1637,10 @@ event-emitter@~0.3.4:
     d "~0.1.1"
     es5-ext "~0.10.7"
 
+events@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
+
 eventsource@0.1.6:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/eventsource/-/eventsource-0.1.6.tgz#0acede849ed7dd1ccc32c811bb11b944d4f29232"
@@ -1621,6 +1688,10 @@ extend@3.0.0, extend@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.0.tgz#5a474353b9f3353ddd8176dfd37b91c83a46f1d4"
 
+extend@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
+
 extend@~1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-1.2.1.tgz#a0f5fd6cfc83a5fe49ef698d60ec8a624dd4576c"
@@ -1628,6 +1699,14 @@ extend@~1.2.1:
 extsprintf@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.0.2.tgz#e1080e0658e300b06294990cc70e1502235fd550"
+
+fast-deep-equal@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz#96256a3bc975595eb36d82e9929d060d893439ff"
+
+fast-json-stable-stringify@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
 
 fast-levenshtein@~2.0.4:
   version "2.0.6"
@@ -1708,6 +1787,14 @@ form-data@0.2.0:
     combined-stream "~0.0.4"
     mime-types "~2.0.3"
 
+form-data@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.1.tgz#6fb94fbd71885306d73d15cc497fe4cc4ecd44bf"
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.5"
+    mime-types "^2.1.12"
+
 form-data@~2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.1.2.tgz#89c3534008b97eada4cbb157d58f6f5df025eae4"
@@ -1716,9 +1803,19 @@ form-data@~2.1.1:
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
 
+formatio@1.2.0, formatio@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/formatio/-/formatio-1.2.0.tgz#f3b2167d9068c4698a8d51f4f760a39a54d818eb"
+  dependencies:
+    samsam "1.x"
+
 formidable@1.0.14, formidable@~1.0.14:
   version "1.0.14"
   resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.0.14.tgz#2b3f4c411cbb5fdd695c44843e2a23514a43231a"
+
+formidable@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.1.1.tgz#96b8886f7c3c3508b932d6bd70c4d3a88f35f1a9"
 
 fresh@0.2.4:
   version "0.2.4"
@@ -1904,6 +2001,10 @@ has-ansi@^2.0.0:
   dependencies:
     ansi-regex "^2.0.0"
 
+has-flag@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-2.0.0.tgz#e8207af1cc7b30d446cc70b734b5e8be18f88d51"
+
 has-unicode@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
@@ -1932,6 +2033,15 @@ hawk@^2.3.1:
     hoek "2.x.x"
     sntp "1.x.x"
 
+hawk@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/hawk/-/hawk-6.0.2.tgz#af4d914eb065f9b5ce4d9d11c1cb2126eecc3038"
+  dependencies:
+    boom "4.x.x"
+    cryptiles "3.x.x"
+    hoek "4.x.x"
+    sntp "2.x.x"
+
 hawk@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/hawk/-/hawk-1.0.0.tgz#b90bb169807285411da7ffcb8dd2598502d3b52d"
@@ -1957,6 +2067,10 @@ hoek@0.9.x:
 hoek@2.x.x:
   version "2.16.3"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
+
+hoek@4.x.x:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.0.tgz#72d9d0754f7fe25ca2d01ad8f8f9a9449a89526d"
 
 home-or-tmp@^2.0.0:
   version "2.0.0"
@@ -2300,6 +2414,10 @@ jsesc@~0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
 
+json-schema-traverse@^0.3.0:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz#349a6d44c53a51de89b40805c5d5e59b417d3340"
+
 json-schema@0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
@@ -2370,6 +2488,10 @@ juice@^2.0.0:
     slick "1.12.2"
     web-resource-inliner "2.0.0"
 
+just-extend@^1.1.26:
+  version "1.1.27"
+  resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-1.1.27.tgz#ec6e79410ff914e472652abfa0e603c03d60e905"
+
 jwa@^1.1.4:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/jwa/-/jwa-1.1.5.tgz#a0552ce0220742cd52e153774a32905c30e756e5"
@@ -2428,6 +2550,10 @@ lodash.clonedeep@^4.3.2:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
 
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+
 lodash.pickby@^4.0.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.pickby/-/lodash.pickby-4.6.0.tgz#7dea21d8c18d7703a27c704c15d3b84a67e33aff"
@@ -2440,7 +2566,7 @@ lodash@^3.10.1, lodash@^3.6.0:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
-lodash@^4.0.0, lodash@^4.0.1, lodash@^4.1.0, lodash@^4.11.1, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.5.1:
+lodash@^4.0.0, lodash@^4.0.1, lodash@^4.1.0, lodash@^4.11.1, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.5.1:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -2451,6 +2577,14 @@ lodash@~3.5.0:
 lodash@~4.16.4:
   version "4.16.6"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.16.6.tgz#d22c9ac660288f3843e16ba7d2b5d06cca27d777"
+
+lolex@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-1.6.0.tgz#3a9a0283452a47d7439e72731b9e07d7386e49f6"
+
+lolex@^2.2.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-2.3.1.tgz#3d2319894471ea0950ef64692ead2a5318cff362"
 
 longest@^1.0.1:
   version "1.0.1"
@@ -2545,7 +2679,7 @@ methods@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.0.tgz#5dca4ee12df52ff3b056145986a8f01cbc86436f"
 
-methods@~1.1.1:
+methods@^1.1.1, methods@~1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
 
@@ -2576,6 +2710,10 @@ mime@1.2.11, mime@~1.2.11, mime@~1.2.9:
 mime@1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.3.4.tgz#115f9e3b6b3daf2959983cb38f149a2d40eb5d53"
+
+mime@^1.4.1:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-1.5.0.tgz#59c20e03ae116089edeb7d3b34a6788c5b3cccea"
 
 mimer@*:
   version "0.2.1"
@@ -2670,6 +2808,10 @@ ms@0.7.2, ms@^0.7.1:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.2.tgz#ae25cf2512b3885a1d95d7f037868d8431124765"
 
+ms@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
+
 mute-stream@0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.5.tgz#8fbfabb0a98a253d3184331f9e8deb7372fac6c0"
@@ -2693,6 +2835,16 @@ negotiator@0.4.9:
 next-tick@~0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-0.2.2.tgz#75da4a927ee5887e39065880065b7336413b310d"
+
+nise@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/nise/-/nise-1.2.0.tgz#079d6cadbbcb12ba30e38f1c999f36ad4d6baa53"
+  dependencies:
+    formatio "^1.2.0"
+    just-extend "^1.1.26"
+    lolex "^1.6.0"
+    path-to-regexp "^1.7.0"
+    text-encoding "^0.6.4"
 
 nock@^4.0.0:
   version "4.1.0"
@@ -2925,6 +3077,12 @@ path-to-regexp@0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.3.tgz#21b9ab82274279de25b156ea08fd12ca51b8aecb"
 
+path-to-regexp@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
+  dependencies:
+    isarray "0.0.1"
+
 path-type@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-1.1.0.tgz#59c44f7ee491da704da415da5a4070ba4f8fe441"
@@ -2985,9 +3143,15 @@ promise@^6.1.0:
   dependencies:
     asap "~1.0.0"
 
-promise@^7.0.0, promise@^7.0.1, promise@^7.0.4, promise@^7.1.1:
+promise@^7.0.1, promise@^7.0.4, promise@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/promise/-/promise-7.1.1.tgz#489654c692616b8aa55b0724fa809bb7db49c5bf"
+  dependencies:
+    asap "~2.0.3"
+
+promise@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/promise/-/promise-8.0.1.tgz#e45d68b00a17647b6da711bf85ed6ed47208f450"
   dependencies:
     asap "~2.0.3"
 
@@ -3102,18 +3266,19 @@ pug@^2.0.0-beta5:
     pug-runtime "^2.0.3"
     pug-strip-comments "^1.0.2"
 
-pulse-publisher@^1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/pulse-publisher/-/pulse-publisher-1.1.4.tgz#b73f289802bce28981d089f77190d5ab6147e313"
+pulse-publisher@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/pulse-publisher/-/pulse-publisher-3.0.2.tgz#d6d8f8c2bac1a03be2b00eb87130b9e56227be4b"
   dependencies:
-    ajv "^4.8.2"
+    ajv "^5.3.0"
     amqplib "^0.5.1"
-    aws-sdk "^2.5.3"
-    babel-runtime "^6.20.0"
-    debug "^2.0.0"
+    aws-sdk "^2.148.0"
+    babel-runtime "^6.26.0"
+    debug "^3.1.0"
     lodash "^4.0.0"
-    promise "^7.0.0"
+    promise "^8.0.1"
     slugid "^1.1.0"
+    taskcluster-client "^3.0.3"
 
 punycode@1.3.2:
   version "1.3.2"
@@ -3138,6 +3303,10 @@ qs@2.3.3:
 qs@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-4.0.0.tgz#c31d9b74ec27df75e543a86c78728ed8d4623607"
+
+qs@^6.5.1:
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
 
 qs@~6.3.0:
   version "6.3.2"
@@ -3255,6 +3424,10 @@ regenerate@^1.2.1:
 regenerator-runtime@^0.10.0:
   version "0.10.3"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.3.tgz#8c4367a904b51ea62a908ac310bf99ff90a82a3e"
+
+regenerator-runtime@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz#7e54fe5b5ccd5d6624ea6255c3473be090b802e1"
 
 regenerator-transform@0.9.8:
   version "0.9.8"
@@ -3410,6 +3583,10 @@ safe-buffer@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.0.1.tgz#d263ca54696cd8a306b5ca6551e92de57918fbe7"
 
+samsam@1.x:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.3.0.tgz#8d1d9350e25622da30de3e44ba692b5221ab7c50"
+
 sass-graph@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/sass-graph/-/sass-graph-2.1.2.tgz#965104be23e8103cb7e5f710df65935b317da57b"
@@ -3421,6 +3598,10 @@ sass-graph@^2.1.1:
 sax@1.1.5, sax@>=0.6.0, sax@^1.1.4:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.1.5.tgz#1da50a8d00cdecd59405659f5ff85349fe773743"
+
+sax@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
 
 "semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5":
   version "5.3.0"
@@ -3481,6 +3662,18 @@ signal-exit@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
 
+sinon@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-4.1.2.tgz#65610521d926fb53742dd84cd599f0b89a82f440"
+  dependencies:
+    diff "^3.1.0"
+    formatio "1.2.0"
+    lodash.get "^4.4.2"
+    lolex "^2.2.0"
+    nise "^1.2.0"
+    supports-color "^4.4.0"
+    type-detect "^4.0.0"
+
 slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
@@ -3510,6 +3703,12 @@ sntp@1.x.x:
   resolved "https://registry.yarnpkg.com/sntp/-/sntp-1.0.9.tgz#6541184cc90aeea6c6e7b35e2659082443c66198"
   dependencies:
     hoek "2.x.x"
+
+sntp@2.x.x:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/sntp/-/sntp-2.1.0.tgz#2c6cec14fedc2222739caf9b5c3d85d1cc5a2cc8"
+  dependencies:
+    hoek "4.x.x"
 
 sockjs-client@^1.0.3:
   version "1.1.2"
@@ -3697,6 +3896,21 @@ superagent@^1.1.0, superagent@~1.7.0:
     readable-stream "1.0.27-1"
     reduce-component "1.0.1"
 
+superagent@~3.8.1:
+  version "3.8.1"
+  resolved "https://registry.yarnpkg.com/superagent/-/superagent-3.8.1.tgz#2571fd921f3fcdba43ac68c3b35c91951532701f"
+  dependencies:
+    component-emitter "^1.2.0"
+    cookiejar "^2.1.0"
+    debug "^3.1.0"
+    extend "^3.0.0"
+    form-data "^2.3.1"
+    formidable "^1.1.1"
+    methods "^1.1.1"
+    mime "^1.4.1"
+    qs "^6.5.1"
+    readable-stream "^2.0.5"
+
 supports-color@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-1.2.0.tgz#ff1ed1e61169d06b3cf2d588e188b18d8847e17e"
@@ -3704,6 +3918,12 @@ supports-color@1.2.0:
 supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
+
+supports-color@^4.4.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.5.0.tgz#be7a0de484dec5c5cddf8b3d59125044912f635b"
+  dependencies:
+    has-flag "^2.0.0"
 
 "symbol-tree@>= 3.1.0 < 4.0.0":
   version "3.2.2"
@@ -3770,6 +3990,19 @@ taskcluster-client@^1.0.1, taskcluster-client@^1.2.0:
     url-join "^0.0.1"
   optionalDependencies:
     sockjs-client "^1.0.3"
+
+taskcluster-client@^3.0.3, taskcluster-client@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/taskcluster-client/-/taskcluster-client-3.1.0.tgz#6f3bbf6ba4d6c149f11ab0cc23ef4f333c19a521"
+  dependencies:
+    amqplib "^0.5.1"
+    babel-runtime "^6.26.0"
+    debug "^3.1.0"
+    hawk "^6.0.2"
+    lodash "^4.17.4"
+    promise "^8.0.1"
+    slugid "^1.1.0"
+    superagent "~3.8.1"
 
 taskcluster-lib-api@3.2.2:
   version "3.2.2"
@@ -3912,6 +4145,10 @@ templayed@*:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/templayed/-/templayed-0.2.3.tgz#4706df625bc6aecd86b7c9f6b0fb548b95cdf769"
 
+text-encoding@^0.6.4:
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/text-encoding/-/text-encoding-0.6.4.tgz#e399a982257a276dae428bb92845cb71bdc26d19"
+
 text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
@@ -4013,6 +4250,10 @@ type-detect@0.1.1:
 type-detect@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-1.0.0.tgz#762217cc06db258ec48908a1298e8b95121e8ea2"
+
+type-detect@^4.0.0:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.5.tgz#d70e5bc81db6de2a381bcaca0c6e0cbdc7635de2"
 
 type-is@^1.6.10, type-is@~1.6.6:
   version "1.6.14"
@@ -4120,6 +4361,10 @@ utils-merge@1.0.0:
 uuid@3.0.0, uuid@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.0.tgz#6728fc0459c450d796a99c31837569bdf672d728"
+
+uuid@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
 
 uuid@^2.0.1, uuid@^2.0.2:
   version "2.0.3"
@@ -4257,11 +4502,24 @@ xml2js@0.4.15:
     sax ">=0.6.0"
     xmlbuilder ">=2.4.6"
 
+xml2js@0.4.17:
+  version "0.4.17"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.17.tgz#17be93eaae3f3b779359c795b419705a8817e868"
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "^4.1.0"
+
 xmlbuilder@2.6.2, xmlbuilder@>=2.4.6:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-2.6.2.tgz#f916f6d10d45dc171b1be2e6e673fb6e0cc35d0a"
   dependencies:
     lodash "~3.5.0"
+
+xmlbuilder@4.2.1, xmlbuilder@^4.1.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-4.2.1.tgz#aa58a3041a066f90eaa16c2f5389ff19f3f461a5"
+  dependencies:
+    lodash "^4.0.0"
 
 xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
   version "4.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2322,6 +2322,10 @@ json5@^0.5.0:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
 
+jsone@^0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/jsone/-/jsone-0.0.0.tgz#565938826fc606af033a0439071711c73c6c2f91"
+
 jsonify@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2414,6 +2414,10 @@ jsesc@~0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
 
+json-e@^2.3.4:
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/json-e/-/json-e-2.3.4.tgz#49673ca14cd0a88d594434b71c6888f57b8b6ce6"
+
 json-schema-traverse@^0.3.0:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz#349a6d44c53a51de89b40805c5d5e59b417d3340"
@@ -2439,10 +2443,6 @@ json3@^3.3.2:
 json5@^0.5.0:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
-
-jsone@^0.0.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/jsone/-/jsone-0.0.0.tgz#565938826fc606af033a0439071711c73c6c2f91"
 
 jsonify@~0.0.0:
   version "0.0.0"


### PR DESCRIPTION
As it says on the tin. This is actually made up of three commits to make reviewing easy, but they do not stand alone very well, so we ought to squash them when we land! The middle commit just makes the tests faster because I was annoyed waiting. At some point we can remove the aws bits from the tests as well.