### PR TITLE
Bug 1495918 - use `NO_TEST_SKIP: "true"` rather than `NO_TEST_SKIP: true` in yaml files

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -21,7 +21,7 @@ tasks:
       maxRunTime: 3600
       image: "node:8"
       env:
-        NO_TEST_SKIP: true
+        NO_TEST_SKIP: "true"
       features:
         taskclusterProxy: true
       command:


### PR DESCRIPTION
In task payloads, environment variables must be strings, not booleans.

This fixes `NO_TEST_SKIP` environment variable in the task definition to be a string.

See [bug 1495918](https://bugzilla.mozilla.org/show_bug.cgi?id=1495918#c6) for context.