### PR TITLE
Bug 1499859 - use pulseCredentials

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -40,9 +40,11 @@ defaults:
     region:           !env AWS_REGION
 
   pulse:
-    namespace:               !env PULSE_NAMESPACE
-    expiresAfter:            !env PULSE_EXPIRES_AFTER
-    contact:                 !env PULSE_CONTACT
+    namespace: !env PULSE_NAMESPACE
+    hostname: !env PULSE_HOSTNAME
+    username: !env PULSE_USERNAME
+    password: !env PULSE_PASSWORD
+    vhost: !env PULSE_VHOST
 
   irc:
     server:           !env IRC_SERVER
@@ -60,6 +62,8 @@ production:
   irc:
     queueName:        irc-notifications
     port:             6697
+  pulse:
+    namespace: taskcluster-notify
 
 # Configuration of tests
 test:

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,6 @@
 const debug = require('debug')('notify');
 const aws = require('aws-sdk');
-const {Client, claimedCredentials} = require('taskcluster-lib-pulse');
+const {Client, pulseCredentials} = require('taskcluster-lib-pulse');
 const App = require('taskcluster-lib-app');
 const loader = require('taskcluster-lib-loader');
 const config = require('typed-env-config');
@@ -79,17 +79,10 @@ const load = loader({
   pulseClient: {
     requires: ['cfg', 'monitor'],
     setup: ({cfg, monitor}) => {
-      const {namespace, expiresAfter, contact} = cfg.pulse;
-      const {rootUrl, credentials} = cfg.taskcluster;
       return new Client({
-        namespace,
+        namespace: cfg.pulse.namespace,
         monitor,
-        credentials: claimedCredentials({
-          rootUrl,
-          credentials,
-          namespace,
-          expiresAfter,
-          contact}),
+        credentials: pulseCredentials(cfg.pulse),
       });
     },
   },


### PR DESCRIPTION
This should deploy cleanly, as the existing settings variables are still in place as well as the pulse user.  Cleanup after deployment:
 * remove PULSE_CONTACT, etc.
 * remove `pulse:..` scopes

/cc @Biboswan 