### PR TITLE
Hard-code the listener queue name

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -2,7 +2,6 @@ defaults:
   app:
     sourceEmail:                  !env EMAIL_SOURCE_ADDRESS
     sqsQueueName:                 !env SQS_QUEUE
-    listenerQueueName:            !env LISTENER_QUEUE_NAME
     routePrefix:                  notify
     publishMetaData:              !env:bool PUBLISH_METADATA
     # Rate limits for email: maximum average rate of count/time

--- a/src/handler.js
+++ b/src/handler.js
@@ -8,7 +8,7 @@ const {consume} = require('taskcluster-lib-pulse');
 /** Handler listening for tasks that carries notifications */
 class Handler {
   constructor({notifier, monitor, routePrefix, ignoreTaskReasonResolved, pulseClient, queue, 
-    queueEvents, queueName}) {
+    queueEvents}) {
 
     this.queue = queue;
     this.notifier = notifier;
@@ -17,7 +17,6 @@ class Handler {
     this.ignoreTaskReasonResolved = ignoreTaskReasonResolved;
 
     this.pulseClient = pulseClient;
-    this.queueName = queueName;
     this.bindings = [
       queueEvents.taskCompleted(`route.${routePrefix}.#.on-completed.#`),
       queueEvents.taskCompleted(`route.${routePrefix}.#.on-any.#`),
@@ -32,7 +31,7 @@ class Handler {
     this.pq = await consume({
       client: this.pulseClient,
       bindings: this.bindings,
-      queueName: this.queueName,
+      queueName: 'notifications',
     },
     this.monitor.timedHandler('notification', this.onMessage.bind(this))
     );

--- a/src/main.js
+++ b/src/main.js
@@ -178,7 +178,6 @@ const load = loader({
         queue,
         queueEvents,
         pulseClient,
-        queueName:                cfg.app.listenerQueueName,
       });
       await handler.listen();
       return handler;


### PR DESCRIPTION
There's no good reason to be selecting different queue names in
different situations: we already have a choice of servers, vhosts, and
namespaces.

This came up in redeploying, because LISTENER_QUEUE_NAME isn't set.  Setting it was the easy course, but I figured this was a good cleanup.